### PR TITLE
Quality of life updates for readme and check-health script

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ You can implement this in your YAML pipelines as follows:
   inputs:
       targetType: 'inline'
       script: |
+          mkdir -p "$(Pipeline.Workspace)/ci/drop/pipeline-scripts"
           curl https://raw.githubusercontent.com/DEVDEER/spock-content/main/scripts/check-health.ps1 -o "$(Pipeline.Workspace)/ci/drop/pipeline-scripts/check-health.ps1"
       pwsh: true
       workingDirectory: '$(Pipeline.Workspace)'

--- a/scripts/check-health.ps1
+++ b/scripts/check-health.ps1
@@ -26,10 +26,10 @@ Write-Host "Trying to retrieve response from API on Slot..."
 $tries = 0
 $url = "https://$AppName-$Stage-deploy.azurewebsites.net/health"
 $statusOk = $false
-while ($tries -lt $MaxRetries) {
+while ($tries -lt $MaxRetries -and !$statusOk) {
     $tries++
     Start-Sleep -Seconds 5
-    Write-Host "Sending request to $url ($tries of $maxTries times) ... " -NoNewLine
+    Write-Host "Sending request to $url ($tries of $MaxRetries times) ... " -NoNewLine
     try {
         $response = Invoke-WebRequest $url
         $apiState = $response.StatusCode
@@ -44,8 +44,6 @@ while ($tries -lt $MaxRetries) {
             else {
                 Write-Host "OK: API responded with HEALTHY state" -ForegroundColor Green
             }
-            # break the loop
-            $tries = $maxTries
         }
     }
     catch {


### PR DESCRIPTION
## In README:

Added following line before the download of the `check-health.ps1` script:

`mkdir -p "$(Pipeline.Workspace)/ci/drop/pipeline-scripts"`

This solves an issue that the `check-health.ps1` script could not be downloaded if the target directory is not present in the project yet.

## in check-health.ps1

The script can now make use of `$MaxRetries` and display it properly in the console view of the pipeline.

It now uses `$MaxRetries` correctly to break out of the loop after all retries are used.

`-and $statusOk` added to `while` condition to only continue if the check fails. This solved an issue where the check succeeded but it would still run forever and just display the confirmation without breaking the loop.

