### PR TITLE
Health-Check can check /health endpoint in API and UI Web App

### DIFF
--- a/scripts/check-health.ps1
+++ b/scripts/check-health.ps1
@@ -24,7 +24,7 @@ param (
 
 Write-Host "Trying to retrieve response from API on Slot..."
 $tries = 0
-$url = "https://$AppName-$Stage-deploy.azurewebsites.net/health"
+$url = "https://$AppName-$Stage-deploy.azurewebsites.net/" + ($AppName.StartsWith("ui-") ? "api/health" : "health")
 $statusOk = $false
 while ($tries -lt $MaxRetries) {
     $tries++

--- a/scripts/check-health.ps1
+++ b/scripts/check-health.ps1
@@ -18,13 +18,15 @@ param (
     [ValidateSet('int', 'test', 'prod')]
     $Stage,
     [Parameter()]
+    [string]
+    $healthCheckPath = "health",
+    [Parameter()]
     [int]
     $MaxRetries = 10
 )
-
 Write-Host "Trying to retrieve response from API on Slot..."
 $tries = 0
-$url = "https://$AppName-$Stage-deploy.azurewebsites.net/" + ($AppName.StartsWith("ui-") ? "api/health" : "health")
+$url = "https://$AppName-$Stage-deploy.azurewebsites.net/" + $healthCheckPath)
 $statusOk = $false
 while ($tries -lt $MaxRetries) {
     $tries++


### PR DESCRIPTION
## Health check for UI Web App

Added following ternary statement to the `$url` declaration to choose the `health` endpoint according to the underlaying web app:

`$url = "https://$AppName-$Stage-deploy.azurewebsites.net/" + ($AppName.StartsWith("ui-") ? "api/health" : "health")
`

If the `$AppName` starts with `ui-` the health check checks the `api/health` endpoint because it is not possible to directly have a health check endpoint on just `/health` in NextJs

**Please evaluate if this can work as well for other currently used UI web apps and not just Node UIs. (spock-template)**